### PR TITLE
Added option for defining content id in email attachments

### DIFF
--- a/src/groovy/uk/co/desirableobjects/sendgrid/SendGridEmail.groovy
+++ b/src/groovy/uk/co/desirableobjects/sendgrid/SendGridEmail.groovy
@@ -22,6 +22,7 @@ class SendGridEmail {
     Map headers = [:]
     Map customHandlingInstructions = [:]
     Map<String, File> attachments = [:]
+    Map<String, String> contentIdForAttachments = [:]
 
     private allParameters = [
             username: 'api_user',
@@ -46,6 +47,7 @@ class SendGridEmail {
 
         parameters.putAll(encodeParameters())
         parameters.putAll(addAttachments())
+        parameters.putAll(addContentIdForAttachments())
 
         return parameters
 
@@ -71,6 +73,16 @@ class SendGridEmail {
 
         attachments.each { String filename, File attachment ->
             parameters.put("files[${filename}]" as String, attachment.bytes)
+        }
+
+        return parameters
+    }
+
+    private Map<String, Object> addContentIdForAttachments() {
+        Map<String, Object> parameters = [:]
+
+        contentIdForAttachments.each { String filename, String contentId ->
+            parameters.put("content[${filename}]" as String, contentId)
         }
 
         return parameters

--- a/src/groovy/uk/co/desirableobjects/sendgrid/SendGridEmailBuilder.groovy
+++ b/src/groovy/uk/co/desirableobjects/sendgrid/SendGridEmailBuilder.groovy
@@ -85,6 +85,13 @@ class SendGridEmailBuilder {
         return this
     }
 
+    SendGridEmailBuilder addAttachment(String filename, String contentId, File file) {
+
+        addAttachment(filename, file)
+        email.contentIdForAttachments.put(filename, contentId)
+        return this
+    }
+
     SendGridEmail build() {
         validateRequiredParameters()
         return this.email

--- a/src/groovy/uk/co/desirableobjects/sendgrid/SendGridSendMailDSLDelegate.groovy
+++ b/src/groovy/uk/co/desirableobjects/sendgrid/SendGridSendMailDSLDelegate.groovy
@@ -38,4 +38,8 @@ class SendGridSendMailDSLDelegate {
         return builder.addAttachment(filename, attachment)
     }
 
+    SendGridEmailBuilder attach(String filename, String contentId, File attachment) {
+        return builder.addAttachment(filename, contentId, attachment)
+    }
+
 }


### PR DESCRIPTION
Added an option for defining content ids in email attachments, this allow to send an inline image in the message.

I use this plugin for an app, and I though it could be helpful for others.